### PR TITLE
Added hCaptcha provider

### DIFF
--- a/docs/captcha-providers.md
+++ b/docs/captcha-providers.md
@@ -25,3 +25,15 @@ captchaProvider: {
   }
 },
 ```
+
+## hCaptcha
+
+```
+captchaProvider: {
+  name: 'hcaptcha',
+  config: {
+    secretKey: 'your-key',
+    minimumScore: 0.5
+  }
+},
+```

--- a/server/services/captcha-providers/hcaptcha.js
+++ b/server/services/captcha-providers/hcaptcha.js
@@ -1,0 +1,61 @@
+'use strict'
+const axios = require('axios')
+
+const invertScore = (score) => {
+  return (1 - score).toFixed(2)
+}
+
+module.exports = ({strapi}) => ({
+  async validate(token) {
+    if (!token) {
+      strapi.log.error('Missing hCaptcha Token')
+      return {
+        valid: false,
+        message: 'Missing token',
+        code: 400
+      }
+    }
+    const secret_key = strapi.config.get('plugin.ezforms.captchaProvider.config.secretKey')
+    const url = `https://api.hcaptcha.com/siteverify?secret=${secret_key}&response=${token}`
+    let hcaptcha_verify
+    try {
+      hcaptcha_verify = await axios.post(url)
+    } catch (e) {
+      strapi.log.error(e)
+      return {
+
+        valid: false,
+        message: 'Unable to verify captcha',
+        code: 500
+
+      }
+    }
+
+    if (!hcaptcha_verify.data.success) {
+      strapi.log.error('hcaptcha_verify')
+      strapi.log.error(hcaptcha_verify)
+      return {
+        valid: false,
+        message: 'Unable to verify captcha',
+        code: 500
+      }
+    }
+    
+    const hcaptcha_score = invertScore(hcaptcha_verify.data.score)
+
+    if (hcaptcha_score < strapi.config.get('plugin.ezforms.captchaProvider.config.score')) {
+      return {
+
+        valid: false,
+        message: 'Score Not High Enough',
+        code: 400
+
+      }
+    }
+    return {
+      score: hcaptcha_score,
+      valid: true
+    }
+  },
+})
+

--- a/server/services/captcha-providers/hcaptcha.js
+++ b/server/services/captcha-providers/hcaptcha.js
@@ -1,10 +1,6 @@
 'use strict'
 const axios = require('axios')
 
-const invertScore = (score) => {
-  return (1 - score).toFixed(2)
-}
-
 module.exports = ({strapi}) => ({
   async validate(token) {
     if (!token) {
@@ -40,10 +36,8 @@ module.exports = ({strapi}) => ({
         code: 500
       }
     }
-    
-    const hcaptcha_score = invertScore(hcaptcha_verify.data.score)
 
-    if (hcaptcha_score < strapi.config.get('plugin.ezforms.captchaProvider.config.score')) {
+    if (hcaptcha_verify.data.score < strapi.config.get('plugin.ezforms.captchaProvider.config.score')) {
       return {
 
         valid: false,
@@ -53,7 +47,7 @@ module.exports = ({strapi}) => ({
       }
     }
     return {
-      score: hcaptcha_score,
+      score: hcaptcha_verify.data.score,
       valid: true
     }
   },

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,12 +1,14 @@
 'use strict'
 
 const recaptcha = require('./captcha-providers/recaptcha')
+const hcaptcha = require('./captcha-providers/hcaptcha')
 const email = require('./notification-providers/email')
 const twilio = require('./notification-providers/twilio')
 const formatData = require('./utils/formatData')
 
 module.exports = {
   recaptcha,
+  hcaptcha,
   email,
   twilio,
   formatData

--- a/tests/hcaptcha.test.js
+++ b/tests/hcaptcha.test.js
@@ -1,0 +1,105 @@
+const recaptcha = require('../server/services/captcha-providers/hcaptcha')
+const axios = require('axios')
+
+
+describe('Recaptcha Captcha Provider', function () {
+  let strapi
+
+  beforeEach(async function () {
+    strapi = {
+      config: {
+        get: jest.fn()
+      },
+      log: {
+        error: jest.fn()
+      }
+    }
+
+  })
+
+  test('should return error if no token is provided', async function () {
+    let result = await recaptcha({strapi}).validate()
+
+    expect(result).toEqual({
+      valid: false,
+      message: 'Missing token',
+      code: 400
+    })
+
+  })
+  test('should return error if captcha post failed', async function () {
+
+    jest.spyOn(axios, 'post').mockRejectedValueOnce(new Error('Unable to verify captcha'))
+
+    let result = await recaptcha({strapi}).validate('fakeToken')
+
+    await expect(result).toEqual({
+      valid: false,
+      message: 'Unable to verify captcha',
+      code: 500
+    })
+
+  })
+
+  test('should return error if captcha is unsuccessful', async function () {
+
+    jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      data: {
+        success: false,
+      }
+    })
+
+    let result = await recaptcha({strapi}).validate('fakeToken')
+
+    await expect(result).toEqual({
+      valid: false,
+      message: 'Unable to verify captcha',
+      code: 500
+    })
+
+  })
+  test('should reject due to low score', async function () {
+
+    jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      data: {
+        success: true,
+        score: 0.4,
+      }
+    })
+    strapi.config.get = jest.fn(() => {
+      return .5
+    })
+
+    let result = await recaptcha({strapi}).validate('fakeToken')
+
+    await expect(result).toEqual({
+
+      valid: false,
+      message: 'Score Not High Enough',
+      code: 400
+
+    })
+
+  })
+  test('should be valid captcha', async function () {
+
+    jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      data: {
+        success: true,
+        score: 0.8,
+      }
+    })
+    strapi.config.get = jest.fn(() => {
+      return .5
+    })
+
+    let result = await recaptcha({strapi}).validate('fakeToken')
+
+    await expect(result).toEqual({
+      score: .8,
+      valid: true
+    })
+
+  })
+
+})

--- a/tests/hcaptcha.test.js
+++ b/tests/hcaptcha.test.js
@@ -1,8 +1,8 @@
-const recaptcha = require('../server/services/captcha-providers/hcaptcha')
+const hcaptcha = require('../server/services/captcha-providers/hcaptcha')
 const axios = require('axios')
 
 
-describe('Recaptcha Captcha Provider', function () {
+describe('hCaptcha Captcha Provider', function () {
   let strapi
 
   beforeEach(async function () {
@@ -18,7 +18,7 @@ describe('Recaptcha Captcha Provider', function () {
   })
 
   test('should return error if no token is provided', async function () {
-    let result = await recaptcha({strapi}).validate()
+    let result = await hcaptcha({strapi}).validate()
 
     expect(result).toEqual({
       valid: false,
@@ -31,7 +31,7 @@ describe('Recaptcha Captcha Provider', function () {
 
     jest.spyOn(axios, 'post').mockRejectedValueOnce(new Error('Unable to verify captcha'))
 
-    let result = await recaptcha({strapi}).validate('fakeToken')
+    let result = await hcaptcha({strapi}).validate('fakeToken')
 
     await expect(result).toEqual({
       valid: false,
@@ -49,7 +49,7 @@ describe('Recaptcha Captcha Provider', function () {
       }
     })
 
-    let result = await recaptcha({strapi}).validate('fakeToken')
+    let result = await hcaptcha({strapi}).validate('fakeToken')
 
     await expect(result).toEqual({
       valid: false,
@@ -70,7 +70,7 @@ describe('Recaptcha Captcha Provider', function () {
       return .5
     })
 
-    let result = await recaptcha({strapi}).validate('fakeToken')
+    let result = await hcaptcha({strapi}).validate('fakeToken')
 
     await expect(result).toEqual({
 
@@ -93,7 +93,7 @@ describe('Recaptcha Captcha Provider', function () {
       return .5
     })
 
-    let result = await recaptcha({strapi}).validate('fakeToken')
+    let result = await hcaptcha({strapi}).validate('fakeToken')
 
     await expect(result).toEqual({
       score: .8,


### PR DESCRIPTION
Added hCaptcha as a provider.

I copied the `recaptcha.js` provider and used [this](https://docs.hcaptcha.com/switch#update-server-side-integration) doc to swap out the endpoints.

There is a part about inverting the score in the docs, however running it as is against the same tests as recaptcha seems to work.